### PR TITLE
Add opt-in local cache based on actions/tool-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The action restores from local or cloud based cache both CMake and Ninja. If a `
 
 Works for `x64` and `arm64` hosts on Linux, macOS and Windows.
 
-The desired version can be specified using [semantic versioning ranges](https://docs.npmjs.com/about-semantic-versioning), and also use `install` or `installrc` special tokens to install resp. the [latest stable](./.latest_cmake_version) or [release candidate](./.latest_ninja_version).
+The desired version can be specified using [semantic versioning ranges](https://docs.npmjs.com/about-semantic-versioning), and also use `install` or `installrc` special tokens to install resp. the [latest stable](./.latest_cmake_version) or [release candidate](./.latestrc_cmake_version).
 
 There are two kind of caches:
 - The cloud based [GitHub cache](https://www.npmjs.com/package/@actions/cache). Enabled by default, it can be disabled using the input `useCloudCache:false`. 
@@ -34,11 +34,11 @@ There are two kind of caches:
 Steps of `get-cmake`:
   1. If a `cache-hit` occurs (either local or cloud cache), CMake and Ninja are restored from the cache.
      1. if both local and cloud are enabled, the local cache check goes first.
-  2. If none of the enabled caches hits (`cache-miss`):
+  2. If a `cache-miss` occurs, i.e. none of the enabled caches hits:
      1. the action downloads and installs the desired versions of CMake and Ninja.
-     2. the action stores CMake and Ninja in the enabled caches:
-        1. on the [cloud based GitHub cache](https://www.npmjs.com/package/@actions/cache). This is beneficial for the next run of the workflow especially on _GitHub-hosted runners_.
-        2. on the local GitHub runner cache. This is beneficial for the next run of the workflow on the same _self-hosted runner_.
+     2. the action stores CMake and Ninja for the enabled caches:
+        1. if enabled, on the [cloud based GitHub cache](https://www.npmjs.com/package/@actions/cache). This is beneficial for the next run of the workflow especially on _GitHub-hosted runners_.
+        2. if enabled, on the local GitHub runner cache. This is beneficial for the next run of the workflow on the same _self-hosted runner_.
         
         _Note:_ when there is a `cache-hit`, nothing will be stored in any of the caches.
   3. Adds to the `PATH` environment variable the binary directories for CMake and Ninja.

--- a/__tests__/action_succeeded.localcloud.test.ts
+++ b/__tests__/action_succeeded.localcloud.test.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2022 Luca Cappa
+// Released under the term specified in file LICENSE.txt
+// SPDX short identifier: MIT
+
+import * as os from 'os';
+import * as toolcache from '@actions/tool-cache';
+import * as core from '@actions/core';
+import * as path from 'path'
+import { main, ToolsGetter } from '../src/get-cmake';
+
+// 30 minutes
+jest.setTimeout(30 * 60 * 1000)
+
+const localCacheInput = "__TEST__USE_LOCAL_CACHE";
+const cloudCacheInput = "__TEST__USE_CLOUD_CACHE";
+const localCacheHit = "__TEST__LOCAL_CACHE_HIT";
+const cloudCacheHit = "__TEST__CLOUD_CACHE_HIT";
+
+let restoreCache = jest.spyOn(ToolsGetter.prototype as any, 'restoreCache');
+let saveCache = jest.spyOn(ToolsGetter.prototype as any, 'saveCache');
+
+jest.spyOn(core, 'getInput').mockImplementation((arg: string, options: core.InputOptions | undefined): string => {
+    if (arg === "cmakeVersion")
+        return process.env["CUSTOM_CMAKE_VERSION"] || "";
+    else
+        return "";
+});
+
+jest.spyOn(core, 'getBooleanInput').mockImplementation((arg: string, options: core.InputOptions | undefined): boolean => {
+    switch (arg) {
+        case "useLocalCache":
+            return process.env[localCacheInput] === "true";
+        case "useCloudCache":
+            return process.env[cloudCacheInput] === "true";
+        default:
+            return false;
+    }
+});
+
+var coreSetFailed = jest.spyOn(core, 'setFailed');
+var coreError = jest.spyOn(core, 'error');
+var toolsCacheDir = jest.spyOn(toolcache, 'cacheDir');
+var toolsFind = jest.spyOn(toolcache, 'find');
+
+test('testing get-cmake action success with cloud/local cache enabled', async () => {
+    for (var matrix of [
+        { version: "latest", cloudCache: "true", localCache: "true" },
+        { version: "latest", cloudCache: "true", localCache: "false" },
+        { version: "latest", cloudCache: "false", localCache: "true" },
+        { version: "latest", cloudCache: "false", localCache: "false" }]) {
+
+        process.env.RUNNER_TEMP = path.join(os.tmpdir(), `${process.pid}`);
+        process.env.RUNNER_TOOL_CACHE = path.join(os.tmpdir(), `${process.pid}-cache`);
+        process.env["CUSTOM_CMAKE_VERSION"] = matrix.version;
+        process.env[localCacheInput] = matrix.localCache;
+        process.env[cloudCacheInput] = matrix.cloudCache;
+        await main();
+        expect(coreSetFailed).toBeCalledTimes(0);
+        expect(coreError).toBeCalledTimes(0);
+        expect(toolsCacheDir).toBeCalledTimes(matrix.localCache === "true" ? 1 : 0);
+        expect(toolsFind).toBeCalledTimes(matrix.localCache === "true" ? 1 : 0);
+        expect(saveCache).toBeCalledTimes(matrix.cloudCache === "true" ? 1 : 0);
+        expect(restoreCache).toBeCalledTimes(matrix.cloudCache === "true" ? 1 : 0);
+
+        saveCache.mockReset();
+        restoreCache.mockReset();
+        toolsCacheDir.mockReset();
+        toolsFind.mockReset();
+    }
+});
+
+test('testing get-cmake action success with local or cloud cache hits', async () => {
+    for (var matrix of [
+        { version: "latest", cloudCache: true, localCache: true, localHit: false, cloudHit: true },
+        { version: "latest", cloudCache: false, localCache: true, localHit: false, cloudHit: false },
+        { version: "latest", cloudCache: true, localCache: true, localHit: true, cloudHit: false },
+        { version: "latest", cloudCache: false, localCache: true, localHit: true, cloudHit: false },
+    ]) {
+        saveCache.mockReset().mockResolvedValue(0);
+        restoreCache.mockReset().mockImplementation(
+            async () => {
+                return Promise.resolve(process.env[cloudCacheHit] === 'true' ? "hit" : "");
+            });
+        toolsCacheDir.mockReset().mockResolvedValue("mock");
+        toolsFind.mockReset().mockImplementation((toolName: string, versionSpec: string, arch?: string | undefined): string => {
+            return process.env[localCacheHit] === 'true' ? "hit" : "";
+        });
+
+        console.log(`\n\ntesting for: ${JSON.stringify(matrix)}:\n`)
+        process.env.RUNNER_TEMP = path.join(os.tmpdir(), `${process.pid}`);
+        process.env.RUNNER_TOOL_CACHE = path.join(os.tmpdir(), `${process.pid}-cache`);
+        process.env["CUSTOM_CMAKE_VERSION"] = matrix.version;
+        process.env[localCacheInput] = String(matrix.localCache);
+        process.env[cloudCacheInput] = String(matrix.cloudCache);
+        process.env[localCacheHit] = String(matrix.localHit);
+        process.env[cloudCacheHit] = String(matrix.cloudHit);
+        await main();
+        expect(coreSetFailed).toBeCalledTimes(0);
+        expect(coreError).toBeCalledTimes(0);
+        expect(toolsFind).toBeCalledTimes(matrix.localCache ? 1 : 0);
+        expect(toolsCacheDir).toBeCalledTimes(!matrix.localCache || matrix.localHit ? 0 : 1);
+        expect(saveCache).toBeCalledTimes((matrix.cloudHit || !matrix.cloudCache || matrix.localHit) ? 0 : 1);
+        expect(restoreCache).toBeCalledTimes((matrix.localHit || !matrix.cloudCache) ? 0 : 1);
+    }
+});

--- a/__tests__/action_succeeded.test.ts
+++ b/__tests__/action_succeeded.test.ts
@@ -1,4 +1,5 @@
-// Copyright (c) 2020 Luca Cappa
+// Copyright (c) 2020, 2021, 2022 Luca Cappa
+
 // Released under the term specified in file LICENSE.txt
 // SPDX short identifier: MIT
 
@@ -11,6 +12,10 @@ import { InputOptions } from '@actions/core';
 
 // 30 minutes
 jest.setTimeout(30 * 60 * 1000)
+
+const localCacheInput = "__TEST__USE_LOCAL_CACHE";
+const cloudCacheInput = "__TEST__USE_CLOUD_CACHE";
+
 
 jest.spyOn(cache, 'saveCache').mockImplementation(() =>
     Promise.resolve(0)
@@ -27,9 +32,19 @@ jest.spyOn(core, 'getInput').mockImplementation((arg: string, options: InputOpti
         return "";
 });
 
+jest.spyOn(core, 'getBooleanInput').mockImplementation((arg: string, options: InputOptions | undefined): boolean => {
+    switch (arg) {
+        case "useLocalCache":
+            return process.env["localCacheInput"] === "true";
+        case "useCloudCache":
+            return process.env["cloudCacheInput"] === "true";
+        default:
+            return false;
+    }
+});
+
 var coreSetFailed = jest.spyOn(core, 'setFailed');
 var coreError = jest.spyOn(core, 'error');
-var toolsCacheDir = jest.spyOn(toolcache, 'cacheDir');
 
 test('testing get-cmake action success with default cmake', async () => {
     process.env.RUNNER_TEMP = os.tmpdir();
@@ -50,7 +65,7 @@ test('testing get-cmake action success with specific cmake versions', async () =
     }
 
     // A Linux ARM build is not available before 3.19.x
-    if (process.platform === "linux" && process.arch === "x64" ) {
+    if (process.platform === "linux" && process.arch === "x64") {
         for (var version of ["3.18.3", "3.16.1", "3.5.2", "3.3.0", "3.1.2"]) {
             process.env.RUNNER_TEMP = os.tmpdir();
             process.env["CUSTOM_CMAKE_VERSION"] = version;

--- a/__tests__/cachehit.test.ts
+++ b/__tests__/cachehit.test.ts
@@ -1,4 +1,5 @@
-// Copyright (c) 2020 Luca Cappa
+// Copyright (c) 2020, 2021, 2022 Luca Cappa
+
 // Released under the term specified in file LICENSE.txt
 // SPDX short identifier: MIT
 

--- a/__tests__/cachemiss.test.ts
+++ b/__tests__/cachemiss.test.ts
@@ -1,4 +1,5 @@
-// Copyright (c) 2020 Luca Cappa
+// Copyright (c) 2020, 2021, 2022 Luca Cappa
+
 // Released under the term specified in file LICENSE.txt
 // SPDX short identifier: MIT
 

--- a/__tests__/cacherestorefailure.test.ts
+++ b/__tests__/cacherestorefailure.test.ts
@@ -1,4 +1,5 @@
-// Copyright (c) 2020 Luca Cappa
+// Copyright (c) 2020, 2021, 2022 Luca Cappa
+
 // Released under the term specified in file LICENSE.txt
 // SPDX short identifier: MIT
 
@@ -16,8 +17,7 @@ jest.spyOn(cache, 'saveCache').mockImplementation(() =>
 
 jest.spyOn(cache, 'restoreCache').mockImplementation(() => {
     throw new Error();
-}
-);
+});
 
 test('testing get-cmake with restoreCache failure', async () => {
     process.env.RUNNER_TEMP = os.tmpdir();

--- a/__tests__/notmpdir.test.ts
+++ b/__tests__/notmpdir.test.ts
@@ -1,4 +1,5 @@
-// Copyright (c) 2020 Luca Cappa
+// Copyright (c) 2020, 2021, 2022 Luca Cappa
+
 // Released under the term specified in file LICENSE.txt
 // SPDX short identifier: MIT
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
 inputs:
   cmakeVersion:
     required: false
-    description: "Optional CMake version, expressed with the semantic version syntax, e.g. '~3.25.0' for the most recent 3.25, `ˆ3.25.0` for the most recent 3.x version, or a specific version `3.25.1'. Or `latest` or `latestrc` for the latest stable or release candidate version. If not specified the `latest` is installed."
+    description: "Optional CMake version, expressed with the semantic version syntax, e.g. '~3.25.0' for the most recent 3.25.x, `ˆ3.25.0` for the most recent 3.x version, or a specific version `3.25.1'. Or `latest` or `latestrc` for the latest stable or release candidate version. If not specified the `latest` is installed."
   ninjaVersion:
     required: false
     description: "Optional Ninja version, same syntax as `cmakeVersion` input. If not specified, `latest` is installed"

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@
 # SPDX short identifier: MIT
 
 name: 'get-cmake'
-description: 'Installs (and caches on GitHub cloud cache) CMake and Ninja onto GitHub runners.'
+description: 'Installs CMake and Ninja, and caches them on cloud based GitHub cache, and/or on the local GitHub runner cache.'
 author: 'Luca Cappa https://github.com/lukka'
 runs:
   using: 'node16'
@@ -16,6 +16,14 @@ inputs:
   ninjaVersion:
     required: false
     description: "Optional Ninja version, same syntax as `cmakeVersion` input. If not specified, `latest` is installed"
+  useCloudCache:
+    required: false
+    description: "Optional argument indicating whether to use the cloud based storage of the GitHub cache. Suited for the GitHub-hosted runners."
+    default: true
+  useLocalCache:
+    required: false
+    description: "Optional argument indicating whether to use the local cache on the GitHub runner file system. Suited for the self-hosted GitHub runners."
+    default: false
 
 branding:
   icon: 'terminal'  

--- a/dist/index.js
+++ b/dist/index.js
@@ -48,9 +48,13 @@ function hashCode(text) {
     return hash.toString();
 }
 class ToolsGetter {
-    constructor(cmakeOverride, ninjaOverride) {
+    constructor(cmakeOverride, ninjaOverride, useCloudCache = true, useLocalCache = false) {
         this.cmakeOverride = cmakeOverride;
         this.ninjaOverride = ninjaOverride;
+        this.useCloudCache = useCloudCache;
+        this.useLocalCache = useLocalCache;
+        core.info(`useCloudCache:${this.useCloudCache}`);
+        core.info(`useLocalCache:${this.useLocalCache}`);
         core.info(`user defined cmake version:${this.cmakeOverride}`);
         core.info(`user defined ninja version:${this.ninjaOverride}`);
         this.requestedCMakeVersion = cmakeOverride || ToolsGetter.CMakeDefaultVersion;
@@ -82,23 +86,23 @@ class ToolsGetter {
             yield this.get(cmakePackage, ninjaPackage);
         });
     }
-    static matchRange(theCat, range, toolName) {
+    static matchRange(theCatalog, range, toolName) {
         const targetArchPlat = shared.getArchitecturePlatform();
         try {
-            const packages = theCat[range];
+            const packages = theCatalog[range];
             if (!packages)
-                throw Error(`Cannot find version:'${range}' in the catalog.`);
+                throw Error(`Cannot find '${toolName}' version '${range}' in the catalog.`);
             const aPackage = packages[targetArchPlat];
             if (!aPackage)
-                throw Error(`Cannot find ${toolName} version '${range}' in the catalog for the '${targetArchPlat}' platform.`);
-            // 'range' is a well defined version.
+                throw Error(`Cannot find '${toolName}' version '${range}' in the catalog for the '${targetArchPlat}' platform.`);
+            // return 'range' itself, this is the case where it is a well defined version.
             return range;
         }
         catch (_a) {
             // Try to use the range to find the version ...
             core.debug(`Collecting semvers list... `);
             const matches = [];
-            Object.keys(theCat).forEach(function (release) {
+            Object.keys(theCatalog).forEach(function (release) {
                 try {
                     matches.push(new semver_1.SemVer(release));
                 }
@@ -116,37 +120,90 @@ class ToolsGetter {
     get(cmakePackage, ninjaPackage) {
         return __awaiter(this, void 0, void 0, function* () {
             let key, outPath;
+            let cloudCacheHitKey = undefined;
+            let localCacheHit = false;
+            let localPath = undefined;
             try {
-                core.startGroup(`Compute cache key from the download's URLs`);
+                core.startGroup(`Computing cache key from the downloads' URLs`);
                 // Get an unique output directory name from the URL.
                 const inputHash = `${cmakePackage.url}${ninjaPackage.url}`;
                 key = hashCode(inputHash);
                 core.info(`Cache key: ${key}`);
                 core.debug(`hash('${inputHash}') === '${key}'`);
                 outPath = this.getOutputPath(key);
+                core.info(`Local install root: '${outPath}''.`);
             }
             finally {
                 core.endGroup();
             }
-            let hitKey = undefined;
-            try {
-                core.startGroup(`Restore from cache using key '${key}' into '${outPath}'`);
-                hitKey = yield cache.restoreCache([outPath], key);
-                core.info(hitKey === undefined ? "Cache miss." : "Cache hit.");
+            if (this.useLocalCache) {
+                try {
+                    core.startGroup(`Restoring from local GitHub runner cache using key '${key}' into '${outPath}'`);
+                    localPath = tools.find(ToolsGetter.LocalCacheName, key, process.platform);
+                    // Silly tool-cache API does return an empty string in case of cache miss.
+                    localCacheHit = localPath ? true : false;
+                    core.info(localCacheHit ? "Local cache hit." : "Local cache miss.");
+                }
+                finally {
+                    core.endGroup();
+                }
             }
-            finally {
-                core.endGroup();
+            if (!localCacheHit) {
+                if (this.useCloudCache) {
+                    try {
+                        core.startGroup(`Restoring from GitHub cloud cache using key '${key}' into '${outPath}'`);
+                        cloudCacheHitKey = yield this.restoreCache(outPath, key);
+                        core.info(cloudCacheHitKey === undefined ? "Cloud cache miss." : "Cloud cache hit.");
+                    }
+                    finally {
+                        core.endGroup();
+                    }
+                }
+                if (cloudCacheHitKey === undefined) {
+                    yield core.group("Downloading and extracting CMake", () => __awaiter(this, void 0, void 0, function* () {
+                        const downloaded = yield tools.downloadTool(cmakePackage.url);
+                        yield extractFunction[cmakePackage.dropSuffix](downloaded, outPath);
+                    }));
+                    yield core.group("Downloading and extracting Ninja", () => __awaiter(this, void 0, void 0, function* () {
+                        const downloaded = yield tools.downloadTool(ninjaPackage.url);
+                        yield extractFunction[ninjaPackage.dropSuffix](downloaded, outPath);
+                    }));
+                }
+                yield this.addToolsToPath(outPath, cmakePackage, ninjaPackage);
+                localPath = outPath;
             }
-            if (hitKey === undefined) {
-                yield core.group("Download and extract CMake", () => __awaiter(this, void 0, void 0, function* () {
-                    const downloaded = yield tools.downloadTool(cmakePackage.url);
-                    yield extractFunction[cmakePackage.dropSuffix](downloaded, outPath);
-                }));
-                yield core.group("Download and extract Ninja", () => __awaiter(this, void 0, void 0, function* () {
-                    const downloaded = yield tools.downloadTool(ninjaPackage.url);
-                    yield extractFunction[ninjaPackage.dropSuffix](downloaded, outPath);
-                }));
+            if (this.useCloudCache && cloudCacheHitKey === undefined) {
+                try {
+                    core.startGroup(`Saving to GitHub cloud cache using key '${key}'`);
+                    if (localCacheHit) {
+                        core.info("Skipping saving to cloud cache since there was local cache hit for the computed key.");
+                    }
+                    else if (cloudCacheHitKey === undefined) {
+                        yield this.saveCache([outPath], key);
+                        core.info(`Saved '${outPath}' to the GitHub cache service with key '${key}'.`);
+                    }
+                    else {
+                        core.info("Skipping saving to cloud cache since there was a cache hit for the computed key.");
+                    }
+                }
+                finally {
+                    core.endGroup();
+                }
             }
+            if (this.useLocalCache && !localCacheHit && localPath) {
+                try {
+                    core.startGroup(`Saving to local cache using key '${key}' from '${outPath}'`);
+                    yield tools.cacheDir(localPath, ToolsGetter.LocalCacheName, key, process.platform);
+                    core.info(`Saved '${outPath}' to the local GitHub runner cache with key '${key}'.`);
+                }
+                finally {
+                    core.endGroup();
+                }
+            }
+        });
+    }
+    addToolsToPath(outPath, cmakePackage, ninjaPackage) {
+        return __awaiter(this, void 0, void 0, function* () {
             try {
                 if (!cmakePackage.fileName) {
                     throw new Error("The file name of the CMake archive is required but it is missing!");
@@ -157,12 +214,12 @@ class ToolsGetter {
                 core.startGroup(`Add CMake and Ninja to PATH`);
                 const cmakePath = path.join(outPath, cmakePackage.fileName.replace(cmakePackage.dropSuffix, ''), cmakePackage.binPath);
                 const ninjaPath = path.join(outPath, ninjaPackage.fileName.replace(ninjaPackage.dropSuffix, ''));
-                core.info(`CMake path: ${cmakePath}`);
+                core.info(`CMake path: '${cmakePath}'`);
                 core.addPath(cmakePath);
-                core.info(`Ninja path: ${ninjaPath}`);
+                core.info(`Ninja path: '${ninjaPath}'`);
                 core.addPath(ninjaPath);
                 try {
-                    core.startGroup(`Validation of the installed CMake and Ninja`);
+                    core.startGroup(`Validating the installed CMake and Ninja`);
                     const cmakeWhichPath = yield io.which('cmake', true);
                     const ninjaWhichPath = yield io.which('ninja', true);
                     core.info(`CMake actual path is: '${cmakeWhichPath}'`);
@@ -170,19 +227,6 @@ class ToolsGetter {
                 }
                 finally {
                     core.endGroup();
-                }
-            }
-            finally {
-                core.endGroup();
-            }
-            try {
-                core.startGroup(`Save to cache using key '${key}'`);
-                if (hitKey === undefined) {
-                    yield this.saveCache([outPath], key);
-                    core.info(`Save '${outPath}' to the GitHub cache service.`);
-                }
-                else {
-                    core.info("Skipping saving cache since there was a cache hit for the computed key.");
                 }
             }
             finally {
@@ -214,14 +258,18 @@ class ToolsGetter {
             }
         });
     }
+    restoreCache(outPath, key) {
+        return cache.restoreCache([outPath], key);
+    }
 }
 exports.ToolsGetter = ToolsGetter;
 ToolsGetter.CMakeDefaultVersion = 'latest';
 ToolsGetter.NinjaDefaultVersion = 'latest';
+ToolsGetter.LocalCacheName = "cmakeninja";
 function main() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const cmakeGetter = new ToolsGetter(core.getInput('cmakeVersion'), core.getInput('ninjaVersion'));
+            const cmakeGetter = new ToolsGetter(core.getInput('cmakeVersion'), core.getInput('ninjaVersion'), core.getBooleanInput('useCloudCache'), core.getBooleanInput('useLocalCache'));
             yield cmakeGetter.run();
             core.info('get-cmake action execution succeeded');
             process.exitCode = 0;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Luca Cappa
+// Copyright (c) 2020, 2021, 2022 Luca Cappa
 // Released under the term specified in file LICENSE.txt
 // SPDX short identifier: MIT
 


### PR DESCRIPTION
Adds opt-in local cache support based on [tool-cache](https://www.npmjs.com/package/@actions/tool-cache).
By default local cache is is "off", the cloud based cache is "on".
Two new inputs in action.yml are added to opt-in and opt-out of the cloud based and of the local cache.

