### PR TITLE
Apply security recommendations

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -79,7 +79,7 @@ jobs:
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/git/tags \
+            "/repos/${GITHUB_REPOSITORY}/git/tags" \
             -f tag="$TAG_NAME" \
             -f message="Release ${TAG_NAME} - CMake ${CMAKE_VERSION}" \
             -f object="$COMMIT_SHA" \
@@ -99,7 +99,7 @@ jobs:
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/git/refs \
+            "/repos/${GITHUB_REPOSITORY}/git/refs" \
             -f ref="refs/tags/$TAG_NAME" \
             -f sha="$TAG_SHA" \
             --jq '.ref')

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
           ref: main

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -68,9 +68,10 @@ jobs:
         if: steps.check_version.outputs.SHOULD_RELEASE == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          CMAKE_VERSION: ${{ steps.check_version.outputs.CMAKE_VERSION }}
         run: |
           set -e
-          TAG_NAME="v${{ steps.check_version.outputs.CMAKE_VERSION }}"
+          TAG_NAME="v${CMAKE_VERSION}"
           COMMIT_SHA=$(git rev-parse HEAD)
           
           # Create tag object using GitHub API (this creates a verified tag)
@@ -80,7 +81,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/git/tags \
             -f tag="$TAG_NAME" \
-            -f message="Release $TAG_NAME - CMake ${{ steps.check_version.outputs.CMAKE_VERSION }}" \
+            -f message="Release ${TAG_NAME} - CMake ${CMAKE_VERSION}" \
             -f object="$COMMIT_SHA" \
             -f type="commit" \
             --jq '.sha')
@@ -112,24 +113,27 @@ jobs:
           echo "✓ Verified tag $TAG_NAME created and pushed"
 
       - name: Create release summary
+        env:
+          SHOULD_RELEASE: ${{ steps.check_version.outputs.SHOULD_RELEASE }}
+          CMAKE_VERSION: ${{ steps.check_version.outputs.CMAKE_VERSION }}
         run: |
-          if [[ "${{ steps.check_version.outputs.SHOULD_RELEASE }}" == "true" ]]; then
-            echo "## 🎉 Release v${{ steps.check_version.outputs.CMAKE_VERSION }} created!" >> $GITHUB_STEP_SUMMARY
+          if [[ "${SHOULD_RELEASE}" == "true" ]]; then
+            echo "## 🎉 Release v${CMAKE_VERSION} created!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Changes" >> $GITHUB_STEP_SUMMARY
-            echo "- CMake version updated to ${{ steps.check_version.outputs.CMAKE_VERSION }}" >> $GITHUB_STEP_SUMMARY
+            echo "- CMake version updated to ${CMAKE_VERSION}" >> $GITHUB_STEP_SUMMARY
             echo "- Latest branch synced with main" >> $GITHUB_STEP_SUMMARY
-            echo "- Tag \`v${{ steps.check_version.outputs.CMAKE_VERSION }}\` created" >> $GITHUB_STEP_SUMMARY
+            echo "- Tag \`v${CMAKE_VERSION}\` created" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Usage" >> $GITHUB_STEP_SUMMARY
             echo "Users can now reference this release using:" >> $GITHUB_STEP_SUMMARY
             echo '```yaml' >> $GITHUB_STEP_SUMMARY
             echo "- uses: lukka/get-cmake@latest" >> $GITHUB_STEP_SUMMARY
-            echo "- uses: lukka/get-cmake@v${{ steps.check_version.outputs.CMAKE_VERSION }}" >> $GITHUB_STEP_SUMMARY
+            echo "- uses: lukka/get-cmake@v${CMAKE_VERSION}" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           else
             echo "## ℹ️ Latest branch synced, tag already exists" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "- Latest branch updated to match main" >> $GITHUB_STEP_SUMMARY
-            echo "- Tag v${{ steps.check_version.outputs.CMAKE_VERSION }} already exists (not recreated)" >> $GITHUB_STEP_SUMMARY
+            echo "- Tag v${CMAKE_VERSION} already exists (not recreated)" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/build-test-tmpl.yml
+++ b/.github/workflows/build-test-tmpl.yml
@@ -17,12 +17,11 @@ jobs:
   build_and_test:
     name: '${{ matrix.os }}: build and test'
     runs-on: ${{ matrix.os }}
-    # Without this block the job would receive whatever the repository default
-    # grants. Only the catalog run needs to write, and only to push its branch and
-    # open the automated pull request; every other scope is dropped to 'none'.
-    permissions:
-      contents: write
-      pull-requests: write
+    # The token this job receives is granted by the caller, in 'build-test.yml':
+    # this workflow is invoked once with 'generate-catalog: true' and twice with
+    # 'false', and only the former needs to write. Since a job cannot vary its
+    # 'permissions' according to an input, declaring the grant here would hand the
+    # write scopes to the ordinary build and test invocations too.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-test-tmpl.yml
+++ b/.github/workflows/build-test-tmpl.yml
@@ -23,15 +23,15 @@ jobs:
         os: ${{ fromJson(inputs.runs-on) }}
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       with:
         submodules: true
         ssh-key: ${{ secrets.token }}
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
       with:
         name: catalog
       if: inputs.generate-catalog != true
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6
       with:
         node-version: '24.x'
     - run: npm install
@@ -66,7 +66,7 @@ jobs:
           exit -1
         fi
       shell: bash
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: catalog
         # The marker files are hidden, and upload-artifact drops hidden files unless
@@ -109,7 +109,7 @@ jobs:
       if: ${{ inputs.generate-catalog == true }}
 
     - name: Create the PR for new CMake version(s)
-      uses: peter-evans/create-pull-request@v8
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8
       with:
         title: '[Automated] Adding ${{ env.CMAKE_NEW_VERSIONS }}'
         body: "Add to catalog new CMake version(s): ${{ env.CMAKE_NEW_VERSIONS }}"

--- a/.github/workflows/build-test-tmpl.yml
+++ b/.github/workflows/build-test-tmpl.yml
@@ -17,6 +17,12 @@ jobs:
   build_and_test:
     name: '${{ matrix.os }}: build and test'
     runs-on: ${{ matrix.os }}
+    # Without this block the job would receive whatever the repository default
+    # grants. Only the catalog run needs to write, and only to push its branch and
+    # open the automated pull request; every other scope is dropped to 'none'.
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,6 +9,12 @@ on:
 
 jobs:
   generate_catalog_build_and_test:
+    # This is the only invocation that writes: it pushes the branch holding the
+    # refreshed catalog and opens the automated pull request for it. Every scope
+    # left out of this block is dropped to 'none'.
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/build-test-tmpl.yml
     with:
       runs-on: "['macos-latest']"
@@ -19,6 +25,10 @@ jobs:
 
   build_and_test:
     needs: generate_catalog_build_and_test
+    # These invocations only build and test the action: reading the sources is all
+    # the token is needed for.
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-test-tmpl.yml
     with:
       runs-on: "['windows-latest', 'ubuntu-latest']"
@@ -30,6 +40,8 @@ jobs:
   build_and_test_arm:
     needs: generate_catalog_build_and_test
     if: false #Disable buildjet's arm based runners usage.
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-test-tmpl.yml
     with:
       runs-on: "['buildjet-2vcpu-ubuntu-2204-arm']"

--- a/.github/workflows/functional-tests-tmpl.yml
+++ b/.github/workflows/functional-tests-tmpl.yml
@@ -28,11 +28,11 @@ jobs:
         versions: ${{ fromJson(inputs.versions) }}
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       with:
         submodules: true
         token: ${{ github.token }}
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6
       with:
         node-version: '24.x'
     - uses: ./

--- a/.github/workflows/functional-tests-tmpl.yml
+++ b/.github/workflows/functional-tests-tmpl.yml
@@ -20,6 +20,10 @@ jobs:
   test_user_provided_versions:
     name: '${{ matrix.os }}: functional test (${{ matrix.versions }})'
     runs-on: ${{ matrix.os }}
+    # The job only checks the repository out and runs the action under test, so
+    # read access to the contents is all its token ever needs.
+    permissions:
+      contents: read
     continue-on-error: ${{ inputs.experimental }}
     strategy:
       fail-fast: false

--- a/.github/workflows/functional-tests-tmpl.yml
+++ b/.github/workflows/functional-tests-tmpl.yml
@@ -41,11 +41,12 @@ jobs:
         cmakeVersion: ${{ fromJSON(matrix.versions).cmake }}
         ninjaVersion: ${{ fromJSON(matrix.versions).ninja }}
     - name: CMake version check ${{ fromJSON(matrix.versions).cmake }}
+      env:
+        CMAKE_REQUESTED_VER: ${{ fromJSON(matrix.versions).cmake }}
       run: |
         which cmake
         cmake --version
         CMAKE_VER="$(cmake --version)"
-        CMAKE_REQUESTED_VER="${{ fromJSON(matrix.versions).cmake }}"
         case ${CMAKE_REQUESTED_VER} in
           'latest')
             EXPECTED_CMAKE_VER=`cat .latest_cmake_version`
@@ -77,11 +78,12 @@ jobs:
         fi
       shell: bash
     - name: ninja version check ${{ fromJSON(matrix.versions).ninja }}
+      env:
+        NINJA_REQUESTED_VER: ${{ fromJSON(matrix.versions).ninja }}
       run: |
         which ninja
         ninja --version
         NINJA_VER="$(ninja --version)"
-        NINJA_REQUESTED_VER="${{ fromJSON(matrix.versions).ninja }}"
         case ${NINJA_REQUESTED_VER} in
           'latest')
             EXPECTED_NINJA_VER=`cat .latest_ninja_version`

--- a/.github/workflows/sync-latest-and-tag.yml
+++ b/.github/workflows/sync-latest-and-tag.yml
@@ -78,7 +78,7 @@ jobs:
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/git/tags \
+            "/repos/${GITHUB_REPOSITORY}/git/tags" \
             -f tag="$TAG_NAME" \
             -f message="Release $TAG_NAME" \
             -f object="$COMMIT_SHA" \
@@ -98,7 +98,7 @@ jobs:
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/git/refs \
+            "/repos/${GITHUB_REPOSITORY}/git/refs" \
             -f ref="refs/tags/$TAG_NAME" \
             -f sha="$TAG_SHA" \
             --jq '.ref')

--- a/.github/workflows/sync-latest-and-tag.yml
+++ b/.github/workflows/sync-latest-and-tag.yml
@@ -35,9 +35,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Validate tag name
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
         run: |
-          TAG_NAME="${{ inputs.tag_name }}"
-          
           # Validate tag format (should start with 'v' and be followed by version)
           if ! [[ "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
             echo "Error: Tag name '$TAG_NAME' does not match expected format (e.g., v4.2.3 or v4.2.3-rc1)"
@@ -68,9 +68,9 @@ jobs:
       - name: Create and push tag
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ inputs.tag_name }}
         run: |
           set -e
-          TAG_NAME="${{ inputs.tag_name }}"
           COMMIT_SHA=$(git rev-parse HEAD)
           
           # Create tag object using GitHub API (this creates a verified tag)
@@ -112,12 +112,14 @@ jobs:
           echo "✓ Verified tag $TAG_NAME created and pushed"
 
       - name: Summary
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
         run: |
           echo "## Release completed successfully! 🎉" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- ✓ Latest branch synced with main" >> $GITHUB_STEP_SUMMARY
-          echo "- ✓ Tag \`${{ inputs.tag_name }}\` created" >> $GITHUB_STEP_SUMMARY
+          echo "- ✓ Tag \`${TAG_NAME}\` created" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Users can now reference this release using:" >> $GITHUB_STEP_SUMMARY
           echo "- \`@latest\` - for the latest stable version" >> $GITHUB_STEP_SUMMARY
-          echo "- \`@${{ inputs.tag_name }}\` - for this specific version" >> $GITHUB_STEP_SUMMARY
+          echo "- \`@${TAG_NAME}\` - for this specific version" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sync-latest-and-tag.yml
+++ b/.github/workflows/sync-latest-and-tag.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
           ref: main


### PR DESCRIPTION
[ Note : my initial intention was to audit the action implementation, not the CI Workflow, however, I learned in the process and thought it would not hurt to suggest the following changes. "1" and "2" are low-hanging fruits addressing low to medium security risk with minimal impact. I understand that "3" can have an impact on your development workflow and you may choose to only apply it to the Peter Evans action or simply drop it. ]

## Security: Apply security recommendations to reduce shell injection & supply chain risks. 

This PR addresses three security weaknesses identified through a GitHub Copilot security audit of the GitHub Actions workflows.

---

### 1 — Shell injection via `inputs.tag_name` (`sync-latest-and-tag.yml`)

`${{ inputs.tag_name }}` was interpolated directly inside `run:` shell scripts. GitHub evaluates `${{ }}` expressions **before** the shell process starts, meaning shell metacharacters in the input are executed as code, bypassing any subsequent validation.

**Fix:** Bound the input to an `env:` variable in all three affected steps. The shell then receives it as a data string, never as executable code.

> **Reference:** [GitHub Docs — Use an intermediate environment variable](https://docs.github.com/en/actions/reference/security/secure-use#using-an-intermediate-environment-variable)

---

### 2 — Shell injection via step output `CMAKE_VERSION` (`auto-release.yml`)

`${{ steps.check_version.outputs.CMAKE_VERSION }}` was interpolated bare into shell scripts. This value originates from `.latest_cmake_version` on the `main` branch — a file a crafted PR could modify. If merged, the injected shell would run with `contents: write` permissions, enabling arbitrary tag/branch manipulation and potentially poisoning `lukka/get-cmake@latest` for all downstream users.

**Fix:** Same approach — bound all step output references to `env:` variables before use in `run:` blocks.

> **Reference:** [GitHub Docs — Use an intermediate environment variable](https://docs.github.com/en/actions/reference/security/secure-use#using-an-intermediate-environment-variable)

---

### 3 — Third-party actions pinned to mutable tags (supply chain risk)

All third-party actions were referenced via mutable version tags (e.g. `@v7`). Tags can be silently moved to a malicious commit if an upstream repository or its owner account is compromised — the next workflow run picks up the new code with no diff or alert.

**Fix:** Pinned all 5 actions to their full commit SHA across 4 workflow files. The original tag name is preserved in a comment for readability.

| Action | Tag | Pinned SHA |
|---|---|---|
| `actions/checkout` | v7 | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
| `actions/download-artifact` | v8 | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` |
| `actions/setup-node` | v6 | `249970729cb0ef3589644e2896645e5dc5ba9c38` |
| `actions/upload-artifact` | v7 | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `peter-evans/create-pull-request` | v8 | `5f6978faf089d4d20b00c7766989d076bb2fc7f1` |

> **Reference:** [GitHub Docs — Pin actions to a full-length commit SHA](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions)
