### PR TITLE
Compare the generated CMake versions against main, not against the checked out ref

### DIFF
--- a/.github/workflows/build-test-tmpl.yml
+++ b/.github/workflows/build-test-tmpl.yml
@@ -78,10 +78,16 @@ jobs:
     - name: If there is a new CMake version, create a Git commit for the PR
       id: git-check
       run: |
-        if ! git diff --exit-code .latest_cmake_version ; then
+        # Compare the freshly generated versions against 'main', the branch the
+        # automated pull request targets, and not against the checked out ref: a
+        # branch forked before the last version bump still carries the previous
+        # version, hence it would look like it introduces a new one and would spawn
+        # a duplicate of an already merged automated pull request.
+        git fetch --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+        if ! git diff --exit-code origin/main -- .latest_cmake_version ; then
           export CMAKE_NEW_VERSIONS=cmake-v$(cat .latest_cmake_version)
         fi
-        if ! git diff --exit-code .latestrc_cmake_version ; then
+        if ! git diff --exit-code origin/main -- .latestrc_cmake_version ; then
           export CMAKE_NEW_VERSIONS="${CMAKE_NEW_VERSIONS} cmake-rc-v$(cat .latestrc_cmake_version)"
         fi
         if [[ -n "${CMAKE_NEW_VERSIONS}" ]]; then


### PR DESCRIPTION
Fixes the spurious `[Automated] Adding cmake-vX.Y.Z` pull requests — such as #271 — that duplicate an already merged one.

### Root cause

`build-test.yml` triggers on `push:` and `pull_request:` with no branch filter, so `generate_catalog_build_and_test` regenerates the catalog on **every** branch, and the auto-PR steps are gated only on `inputs.generate-catalog == true`.

The "is there a new version?" test was:

```bash
git diff --exit-code .latest_cmake_version
```

which compares the regenerated value against **the branch being built**, not against the branch the automated PR targets. Any branch forked before the last version bump still carries the previous version, so the comparison always reports a new release:

| branch | committed `.latest_cmake_version` | regenerated | old verdict |
|---|---|---|---|
| `main` | 4.4.2 | 4.4.2 | no new version |
| any PR branch forked at v4.4.1 | 4.4.1 | 4.4.2 | **new version** → duplicate PR |

That is exactly what produced #271: a push to a feature PR branch at 22:59Z opened it at 23:05Z, hours after #270 had already merged 4.4.2 into `main`. The resulting PR does not even add 4.4.2 (`main` already has it) — its whole diff is incidental catalog churn under a misleading title.

### Fix

Fetch the tip of `main` and compare against it, for both the stable and the rc marker files. Behaviour on a run on `main` is unchanged, since there `HEAD == origin/main`.

### Verification

Simulated in a worktree at `4a7d025` (v4.4.1) with the marker file regenerated to `4.4.2`:

```
OLD  (vs checked-out ref): NEW VERSION -> opens duplicate PR  <-- the bug
NEW  (vs origin/main):     no new version -> no PR            <-- fixed
NEW  (tree=4.4.3):         NEW VERSION -> opens PR            <-- still works
```

### Note

A much narrower race remains: if a new CMake release appears while CI runs on a feature branch, that run can still open the PR the nightly run on `main` would have opened. `peter-evans/create-pull-request` reuses the deterministic branch name, so it updates the existing PR rather than duplicating it. Restricting the auto-PR steps to `github.event_name == 'schedule'` would close that too; left out here to keep the change focused.
