### PR TITLE
Upload the hidden version marker files in the catalog artifact

### DIFF
--- a/.github/workflows/build-test-tmpl.yml
+++ b/.github/workflows/build-test-tmpl.yml
@@ -69,6 +69,11 @@ jobs:
     - uses: actions/upload-artifact@v7
       with:
         name: catalog
+        # The marker files are hidden, and upload-artifact drops hidden files unless
+        # told otherwise: without this the artifact would carry the catalog alone, and
+        # the downstream jobs would validate the freshly installed CMake and Ninja
+        # against the stale marker files committed in the branch being built.
+        include-hidden-files: true
         path: |
           .latest_ninja_version
           .latest_cmake_version


### PR DESCRIPTION
Fixes the `build_and_test` failure on `windows-latest` and `ubuntu-latest`:

```
ASSERTION FAILED! Instead of '4.4.1', found:
cmake version 4.4.2
```

### Root cause

`generate_catalog_build_and_test` regenerates the catalog and uploads `.latest_ninja_version`, `.latest_cmake_version` and `src/releases-catalog.ts` as the `catalog` artifact. The downstream `build_and_test` jobs download it and assert that the CMake and Ninja installed by the action match the marker files.

`actions/upload-artifact` excludes hidden files by default, and both marker files start with a dot, so they were silently dropped. From the run log:

```
include-hidden-files: false
The least common ancestor is /Users/runner/work/get-cmake/get-cmake. This will be the root directory of the artifact
With the provided path, there will be 1 file uploaded
```

Only `src/releases-catalog.ts` ever reached the artifact. The downstream jobs therefore installed the version coming from the **regenerated** catalog, but compared it against the **stale marker files committed in the branch being built**.

This is invisible on `main`, where the committed marker files always match the regenerated ones. It breaks on any branch forked before the last version bump — for instance run [30722453793](https://github.com/lukka/get-cmake/actions/runs/30722453793), where the action correctly installed CMake 4.4.2 while the checked-out branch still carried `4.4.1`.

### Fix

Set `include-hidden-files: true` on the upload, so the artifact carries the marker files it is meant to carry.

The least common ancestor stays the workspace root, so the extracted layout is unchanged for `src/releases-catalog.ts` and the marker files land back at the root where the assertions read them.
